### PR TITLE
Fix MTP upload comparison and argument usage

### DIFF
--- a/MediaDeviceCopier/MtpDevice.cs
+++ b/MediaDeviceCopier/MtpDevice.cs
@@ -139,9 +139,9 @@ namespace MediaDeviceCopier
 
 			_device.UploadFile(sourceFilePath, targetFilePath);
 
-			// TODO: figure out how to set the file date to match the source file
-			// set the file date to match the source file
-			mtpFileComparisonInfo ??= GetComparisonInfo(_device.GetFileInfo(sourceFilePath));
+                        // TODO: figure out how to set the file date to match the source file
+                        // set the file date to match the source file
+                        mtpFileComparisonInfo ??= GetComparisonInfo(_device.GetFileInfo(targetFilePath));
 			//File.SetLastWriteTime(targetFilePath, mtpFileComparisonInfo.ModifiedDate);
 
 			fileCopyInfo = new()
@@ -163,18 +163,23 @@ namespace MediaDeviceCopier
 				mtpFileComparisonInfo = sourceComparisonInfo;
 				targetComparisonInfo = GetComparisonInfo(new FileInfo(targetFilePath));
 			}
-			else if (fileCopyMode is FileCopyMode.Upload)
-			{
-				sourceComparisonInfo = GetComparisonInfo(new FileInfo(targetFilePath));
-				targetComparisonInfo = GetComparisonInfo(_device.GetFileInfo(sourceFilePath));
-				mtpFileComparisonInfo = targetComparisonInfo;
+                        else if (fileCopyMode is FileCopyMode.Upload)
+                        {
+                                sourceComparisonInfo = GetComparisonInfo(new FileInfo(sourceFilePath));
+                                targetComparisonInfo = GetComparisonInfo(_device.GetFileInfo(targetFilePath));
+                                mtpFileComparisonInfo = targetComparisonInfo;
 			}
 			else
 			{
 				throw new NotImplementedException();
 			}
 
-			return sourceComparisonInfo.Equals(targetComparisonInfo);
+                        if (fileCopyMode is FileCopyMode.Upload)
+                        {
+                                // Modified dates are unreliable when uploading to MTP devices
+                                return sourceComparisonInfo.Length == targetComparisonInfo.Length;
+                        }
+                        return sourceComparisonInfo.Equals(targetComparisonInfo);
 		}
 
 		public string[] GetFiles(string folder)


### PR DESCRIPTION
## Summary
- fix argument used when retrieving MTP file info after upload
- correct comparison order of local and device files
- ignore modified date when checking existing files on upload since MTP upload doesn't preserve timestamps

## Testing
- `dotnet build MediaDeviceCopier/MediaDeviceCopier.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_b_6841b01c213c832284b4e7aadef887c7