### PR TITLE
Add test scaffolding with mock and real MTP device projects

### DIFF
--- a/MediaDeviceCopier.Tests.Mocked/MediaDeviceCopier.Tests.Mocked.csproj
+++ b/MediaDeviceCopier.Tests.Mocked/MediaDeviceCopier.Tests.Mocked.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediaDeviceCopier\MediaDeviceCopier.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MediaDeviceCopier.Tests.Mocked/MockMediaDevice.cs
+++ b/MediaDeviceCopier.Tests.Mocked/MockMediaDevice.cs
@@ -1,0 +1,38 @@
+using MediaDeviceCopier;
+using MediaDevices;
+
+namespace MediaDeviceCopier.Tests.Mocked;
+
+internal class MockMediaDevice : IMediaDevice
+{
+    private readonly Dictionary<string, byte[]> _files = new();
+    private readonly HashSet<string> _folders = new();
+    public bool IsConnected { get; private set; }
+    public string FriendlyName { get; init; } = "MockDevice";
+
+    public void Connect() => IsConnected = true;
+
+    public bool FileExists(string path) => _files.ContainsKey(path);
+
+    public MediaFileInfo GetFileInfo(string path) => throw new NotImplementedException();
+
+    public void DownloadFile(string sourceFilePath, string targetFilePath) => File.WriteAllBytes(targetFilePath, _files[sourceFilePath]);
+
+    public void UploadFile(string sourceFilePath, string targetFilePath) => _files[targetFilePath] = File.ReadAllBytes(sourceFilePath);
+
+    public bool DirectoryExists(string folder) => _folders.Contains(folder);
+
+    public string[] GetFiles(string folder)
+    {
+        if (!DirectoryExists(folder))
+        {
+            throw new DirectoryNotFoundException();
+        }
+
+        return _files.Keys.ToArray();
+    }
+
+    public void AddFolder(string folder) => _folders.Add(folder);
+
+    public void Dispose() { }
+}

--- a/MediaDeviceCopier.Tests.Mocked/MtpDeviceMockTests.cs
+++ b/MediaDeviceCopier.Tests.Mocked/MtpDeviceMockTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using MediaDeviceCopier;
+
+namespace MediaDeviceCopier.Tests.Mocked;
+
+public class MtpDeviceMockTests
+{
+    [Fact]
+    public void GetFiles_InvalidFolder_Throws()
+    {
+        var device = new MtpDevice(new MockMediaDevice());
+        Assert.Throws<DirectoryNotFoundException>(() => device.GetFiles("invalid"));
+    }
+
+    [Fact]
+    public void DeviceFactory_ReturnsMock()
+    {
+        MtpDevice.DeviceFactory = () => new[] { (IMediaDevice)new MockMediaDevice() };
+        var devices = MtpDevice.GetAll();
+        Assert.Single(devices);
+        Assert.Equal("MockDevice", devices[0].FriendlyName);
+    }
+}

--- a/MediaDeviceCopier.Tests.RealDevice/MediaDeviceCopier.Tests.RealDevice.csproj
+++ b/MediaDeviceCopier.Tests.RealDevice/MediaDeviceCopier.Tests.RealDevice.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediaDeviceCopier\MediaDeviceCopier.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MediaDeviceCopier.Tests.RealDevice/RealDeviceTests.cs
+++ b/MediaDeviceCopier.Tests.RealDevice/RealDeviceTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace MediaDeviceCopier.Tests.RealDevice;
+
+public class RealDeviceTests
+{
+    private static MediaDeviceCopier.MtpDevice? GetFirstDevice()
+    {
+        var device = MediaDeviceCopier.MtpDevice.GetAll().FirstOrDefault();
+        return device;
+    }
+
+    [Fact]
+    public void ListDevices_ReturnsAtLeastZero()
+    {
+        var devices = MediaDeviceCopier.MtpDevice.GetAll();
+        Assert.NotNull(devices);
+    }
+
+    [Fact]
+    public void Connect_FirstDevice_IfAvailable()
+    {
+        var device = GetFirstDevice();
+        if (device == null)
+        {
+            return; // no device connected
+        }
+        device.Connect();
+        Assert.True(true);
+    }
+}

--- a/MediaDeviceCopier.sln
+++ b/MediaDeviceCopier.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 17.7.34221.43
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaDeviceCopier", "MediaDeviceCopier\MediaDeviceCopier.csproj", "{4FCD9EE1-D340-45D7-9885-94E7E9D31581}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaDeviceCopier.Tests.Mocked", "MediaDeviceCopier.Tests.Mocked\MediaDeviceCopier.Tests.Mocked.csproj", "{D7A47BF9-6548-4B5C-B4C9-4C9531BB3CB9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaDeviceCopier.Tests.RealDevice", "MediaDeviceCopier.Tests.RealDevice\MediaDeviceCopier.Tests.RealDevice.csproj", "{502B0405-4FFB-4754-80FA-CF7DE58F92C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +19,14 @@ Global
 		{4FCD9EE1-D340-45D7-9885-94E7E9D31581}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FCD9EE1-D340-45D7-9885-94E7E9D31581}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FCD9EE1-D340-45D7-9885-94E7E9D31581}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7A47BF9-6548-4B5C-B4C9-4C9531BB3CB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7A47BF9-6548-4B5C-B4C9-4C9531BB3CB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7A47BF9-6548-4B5C-B4C9-4C9531BB3CB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7A47BF9-6548-4B5C-B4C9-4C9531BB3CB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{502B0405-4FFB-4754-80FA-CF7DE58F92C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{502B0405-4FFB-4754-80FA-CF7DE58F92C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{502B0405-4FFB-4754-80FA-CF7DE58F92C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{502B0405-4FFB-4754-80FA-CF7DE58F92C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MediaDeviceCopier/IMediaDevice.cs
+++ b/MediaDeviceCopier/IMediaDevice.cs
@@ -1,0 +1,16 @@
+namespace MediaDeviceCopier;
+
+using MediaDevices;
+
+public interface IMediaDevice : IDisposable
+{
+    bool IsConnected { get; }
+    string FriendlyName { get; }
+    void Connect();
+    bool FileExists(string path);
+    MediaFileInfo GetFileInfo(string path);
+    void DownloadFile(string sourceFilePath, string targetFilePath);
+    void UploadFile(string sourceFilePath, string targetFilePath);
+    bool DirectoryExists(string folder);
+    string[] GetFiles(string folder);
+}

--- a/MediaDeviceCopier/MediaDeviceWrapper.cs
+++ b/MediaDeviceCopier/MediaDeviceWrapper.cs
@@ -1,0 +1,24 @@
+namespace MediaDeviceCopier;
+
+using MediaDevices;
+
+internal class MediaDeviceWrapper : IMediaDevice
+{
+    private readonly MediaDevice _device;
+
+    public MediaDeviceWrapper(MediaDevice device)
+    {
+        _device = device;
+    }
+
+    public bool IsConnected => _device.IsConnected;
+    public string FriendlyName => _device.FriendlyName;
+    public void Connect() => _device.Connect();
+    public bool FileExists(string path) => _device.FileExists(path);
+    public MediaFileInfo GetFileInfo(string path) => _device.GetFileInfo(path);
+    public void DownloadFile(string sourceFilePath, string targetFilePath) => _device.DownloadFile(sourceFilePath, targetFilePath);
+    public void UploadFile(string sourceFilePath, string targetFilePath) => _device.UploadFile(sourceFilePath, targetFilePath);
+    public bool DirectoryExists(string folder) => _device.DirectoryExists(folder);
+    public string[] GetFiles(string folder) => _device.GetFiles(folder);
+    public void Dispose() => _device.Dispose();
+}


### PR DESCRIPTION
## Summary
- refactor `MtpDevice` to allow injecting an `IMediaDevice`
- wrap `MediaDevice` so tests can substitute fake devices
- add mocked MTP tests
- add real-device tests

## Testing
- `dotnet test MediaDeviceCopier.sln --no-build` *(fails: invalid arguments because packages can't be restored)*

------
https://chatgpt.com/codex/tasks/task_b_6841af9d882c832286431478d29513ca